### PR TITLE
"v1 추천, 스크랩만 반영해서 유저-식당 내적 추가"

### DIFF
--- a/be/src/main/java/com/yumst/be/recommendation/controller/RecommendationController.java
+++ b/be/src/main/java/com/yumst/be/recommendation/controller/RecommendationController.java
@@ -1,0 +1,28 @@
+package com.yumst.be.recommendation.controller;
+
+
+import com.yumst.be.recommendation.service.RecommendationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/recommend")
+@RequiredArgsConstructor
+public class RecommendationController {
+
+    private final RecommendationService recommendationService;
+
+    @GetMapping("/v1/{userId}")
+    public ResponseEntity<List<UUID>> recommendRestaurants(@PathVariable UUID userId) {
+        List<UUID> recommendations = recommendationService.getRecommendedRestaurants(userId);
+        return ResponseEntity.ok(recommendations);
+    }
+}
+

--- a/be/src/main/java/com/yumst/be/recommendation/domain/RecommendationEntity.java
+++ b/be/src/main/java/com/yumst/be/recommendation/domain/RecommendationEntity.java
@@ -1,0 +1,25 @@
+package com.yumst.be.recommendation.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "recommendation")
+@Getter
+@NoArgsConstructor
+public class RecommendationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private UUID id;
+
+    @Column(name = "restaurant_id")
+    private UUID restaurantId;
+
+    @Column(name = "user_id")
+    private UUID userId;
+
+}

--- a/be/src/main/java/com/yumst/be/recommendation/dto/RecommendationResponseDto.java
+++ b/be/src/main/java/com/yumst/be/recommendation/dto/RecommendationResponseDto.java
@@ -1,0 +1,20 @@
+package com.yumst.be.recommendation.dto;
+
+
+public class RecommendationResponseDto {
+    private String restaurantId;
+    private double similarity;
+
+    public RecommendationResponseDto(String restaurantId, double similarity) {
+        this.restaurantId = restaurantId;
+        this.similarity = similarity;
+    }
+
+    public String getRestaurantId() {
+        return restaurantId;
+    }
+
+    public double getSimilarity() {
+        return similarity;
+    }
+}

--- a/be/src/main/java/com/yumst/be/recommendation/repository/RecommendationRepository.java
+++ b/be/src/main/java/com/yumst/be/recommendation/repository/RecommendationRepository.java
@@ -1,0 +1,53 @@
+package com.yumst.be.recommendation.repository;
+
+import com.yumst.be.recommendation.domain.RecommendationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface RecommendationRepository extends JpaRepository<RecommendationEntity, UUID> {
+
+    @Query(value = """
+        WITH review_vectors AS (
+            SELECT
+                restaurant_id::UUID,
+                ARRAY_AGG(COALESCE(review_count, 0)::REAL ORDER BY naver_review_id)::vector AS feature_vector
+            FROM restaurant_naver_review_count
+            GROUP BY restaurant_id
+        ),
+        user_vector AS (
+            SELECT
+                SUM(feature_vector)::vector AS user_pref_vector
+            FROM (
+                SELECT restaurant_id::UUID, 
+                       ARRAY_AGG(COALESCE(review_count, 0)::REAL ORDER BY naver_review_id)::vector AS feature_vector
+                FROM restaurant_naver_review_count
+                WHERE restaurant_id IN (
+                    SELECT restaurant_id FROM user_restaurant_scrap WHERE user_id::UUID = :userId
+                )
+                GROUP BY restaurant_id
+            ) AS user_scrap_vectors
+        )
+        SELECT rv.restaurant_id::UUID
+        FROM review_vectors rv
+        CROSS JOIN user_vector
+        ORDER BY (
+            CAST('[' || array_to_string(
+                rv.feature_vector::real[] || array_fill(0::REAL, ARRAY[
+                    GREATEST(0, array_length(user_vector.user_pref_vector::real[], 1) - array_length(rv.feature_vector::real[], 1)) 
+                ]), ',') || ']' AS vector)
+            <#> 
+            CAST('[' || array_to_string(
+                user_vector.user_pref_vector::real[] || array_fill(0::REAL, ARRAY[
+                    GREATEST(0, array_length(rv.feature_vector::real[], 1) - array_length(user_vector.user_pref_vector::real[], 1)) 
+                ]), ',') || ']' AS vector)
+        ) DESC
+        LIMIT 10;
+        """, nativeQuery = true)
+    List<String> findRecommendations(@Param("userId") UUID userId);
+}

--- a/be/src/main/java/com/yumst/be/recommendation/service/RecommendationService.java
+++ b/be/src/main/java/com/yumst/be/recommendation/service/RecommendationService.java
@@ -1,0 +1,24 @@
+package com.yumst.be.recommendation.service;
+
+import com.yumst.be.recommendation.repository.RecommendationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationService {
+    private final RecommendationRepository recommendationRepository;
+
+    @Transactional(readOnly = true)
+    public List<UUID> getRecommendedRestaurants(UUID userId) {
+        return recommendationRepository.findRecommendations(userId)
+                .stream()
+                .map(UUID::fromString)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- 추천수정
- v1 버전 ai 없는 추천시스템, postgres 안에서 유저-식당 내적 계산해서 10개 반환
- #37 

## 🔑 주요 변경사항
- 스크랩만 반영했습니다
- 추후 회원가입시 선택한 피쳐도 추가필요
- 맞는건지 모르겠음 더 좋은방법 있다면 수정
- 거리 필터하는것도 추가하는중입니다

## 🏞 스크린샷 (선택)
>
<img width="490" alt="image" src="https://github.com/user-attachments/assets/133dedec-5ac0-48ce-a7b9-7e61fcc99198" />



