### PR TITLE
fix: 크롤링 무한 루프 오류 수정

### DIFF
--- a/be/src/main/java/com/yumst/be/batch/config/item/RestaurantProcessorConfig.java
+++ b/be/src/main/java/com/yumst/be/batch/config/item/RestaurantProcessorConfig.java
@@ -60,7 +60,25 @@ public class RestaurantProcessorConfig {
 
                 updateFeature(item, crawlResult);
 
-                NaverInformation naverInformation = modelMapper.map(crawlResult, NaverInformation.class);
+                NaverInformation naverInformation = NaverInformation.builder()
+                        .name(crawlResult.getName())
+                        .category(crawlResult.getCategory())
+                        .latitude(crawlResult.getLatitude())
+                        .longitude(crawlResult.getLongitude())
+                        .mondayHours(crawlResult.getMondayHours())
+                        .tuesdayHours(crawlResult.getTuesdayHours())
+                        .wednesdayHours(crawlResult.getWednesdayHours())
+                        .thursdayHours(crawlResult.getThursdayHours())
+                        .fridayHours(crawlResult.getFridayHours())
+                        .saturdayHours(crawlResult.getSaturdayHours())
+                        .sundayHours(crawlResult.getSundayHours())
+                        .phoneNumber(crawlResult.getPhoneNumber())
+                        .thumbnailUrl(crawlResult.getThumbnailUrl())
+                        .visitorReviewCount(Long.parseLong(crawlResult.getVisitorReviewCount().replace(",", "")))
+                        .blogReviewCount(Long.parseLong(crawlResult.getBlogReviewCount().replace(",", "")))
+                        .rating(Double.parseDouble(crawlResult.getRating()))
+                        .build();
+
                 item.updateNaverCrawlData(naverInformation);
 
                 return item;

--- a/be/src/main/java/com/yumst/be/batch/config/item/RestaurantReaderConfig.java
+++ b/be/src/main/java/com/yumst/be/batch/config/item/RestaurantReaderConfig.java
@@ -55,7 +55,7 @@ public class RestaurantReaderConfig {
         reader.setEntityManagerFactory(entityManagerFactory);
         reader.setPageSize(5);
 
-        reader.setMaxItemCount(100);
+        reader.setMaxItemCount(300);
 
 
         reader.setQueryString("SELECT r FROM Restaurant r " +

--- a/be/src/main/java/com/yumst/be/batch/config/job/CrawlBatchConfig.java
+++ b/be/src/main/java/com/yumst/be/batch/config/job/CrawlBatchConfig.java
@@ -50,7 +50,7 @@ public class CrawlBatchConfig {
 
                 .faultTolerant()
                 .skip(Exception.class)
-                .skipLimit(100)
+                .skipLimit(300)
 
                 // 실패 레코드 기록
                 .listener(restaurantProcessListener)

--- a/be/src/main/java/com/yumst/be/batch/config/listener/RestaurantProcessListener.java
+++ b/be/src/main/java/com/yumst/be/batch/config/listener/RestaurantProcessListener.java
@@ -21,6 +21,10 @@ public class RestaurantProcessListener implements ItemProcessListener<Restaurant
     @Override
     public void onProcessError(Restaurant item, Exception e) {
 
+        if (e.getMessage().length() > 1024) {
+            e = new Exception(e.getMessage().substring(0, 1024));
+        }
+
         FailedRecord failedRecord = FailedRecord.builder()
                 .recordType("PROCESS")
                 .recordDataId(item.getRestaurantId())

--- a/be/src/main/java/com/yumst/be/batch/domain/FailedRecord.java
+++ b/be/src/main/java/com/yumst/be/batch/domain/FailedRecord.java
@@ -1,5 +1,6 @@
 package com.yumst.be.batch.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -23,6 +24,7 @@ public class FailedRecord {
 
     private String recordDataId;
 
+    @Column(length = 1024)
     private String errorMessage;
 
     private LocalDateTime failedAt;

--- a/be/src/main/java/com/yumst/be/crawl/controller/CrawlController.java
+++ b/be/src/main/java/com/yumst/be/crawl/controller/CrawlController.java
@@ -14,7 +14,8 @@ public class CrawlController {
 
     @GetMapping("/crawl")
     public String crawl() {
-        CrawledNaverRestaurant crawl = seleniumService.crawl("이호커피", "서울특별시 마포구 망원동");
+//        CrawledNaverRestaurant crawl = seleniumService.crawl("7번방", "서울특별시 마포구");
+        CrawledNaverRestaurant crawl = seleniumService.crawl("판초", "서울특별시 마포구");
 //        CrawledNaverRestaurant crawl = seleniumService.crawl("하카타분코", "서울");
 
         return crawl.toString();

--- a/be/src/main/java/com/yumst/be/crawl/service/SeleniumService.java
+++ b/be/src/main/java/com/yumst/be/crawl/service/SeleniumService.java
@@ -4,6 +4,7 @@ import com.yumst.be.crawl.dto.CrawledNaverRestaurant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -105,21 +106,34 @@ public class SeleniumService {
     }
 
     private void clickReviewTab() throws InterruptedException {
-
+        // 리뷰 탭 클릭
         List<WebElement> elements = driver.findElements(By.cssSelector("a.tpj9w._tab-menu"));
-
         for (WebElement element : elements) {
             if (element.getText().equals("리뷰")) {
                 element.click();
                 Thread.sleep(1000);
                 element.sendKeys(ENTER);
+                break;  // 리뷰 탭을 찾으면 바로 종료
             }
         }
 
-        // 더보기 클릭
-        wait.until(ExpectedConditions.elementToBeClickable(By.cssSelector("a.dP0sq"))).click();
-        wait.until(ExpectedConditions.elementToBeClickable(By.cssSelector("a.dP0sq"))).click();
+        // "더보기" 버튼 클릭: 최대 두 번 클릭
+        int maxClicks = 3;
+        for (int i = 0; i < maxClicks; i++) {
+            try {
+                WebElement moreButton = wait.until(
+                        ExpectedConditions.elementToBeClickable(By.cssSelector("a.dP0sq"))
+                );
+                moreButton.click();
+                // 클릭 후 버튼이 업데이트 될 시간을 잠깐 대기
+                Thread.sleep(500);
+            } catch (TimeoutException e) {
+                // 더 이상 "더보기" 버튼이 없거나 클릭할 수 없으면 루프 종료
+                break;
+            }
+        }
     }
+
 
     private Map<String, String> ReviewDetail() {
 
@@ -149,7 +163,7 @@ public class SeleniumService {
         List<WebElement> reviews = driver.findElements(By.cssSelector(".dAsGb > span"));
 
         if (reviews.size() == 2) {
-            result.add(null);
+            result.add("0");
         }
 
         for (WebElement review : reviews) {

--- a/be/src/main/java/com/yumst/be/restaurant/domain/embed/NaverInformation.java
+++ b/be/src/main/java/com/yumst/be/restaurant/domain/embed/NaverInformation.java
@@ -2,10 +2,13 @@ package com.yumst.be.restaurant.domain.embed;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @Data
+@NoArgsConstructor
 public class NaverInformation {
 
     private String name;
@@ -32,4 +35,23 @@ public class NaverInformation {
 
     private double rating;
 
+    @Builder
+    public NaverInformation(String name, String category, String latitude, String longitude, String mondayHours, String tuesdayHours, String wednesdayHours, String thursdayHours, String fridayHours, String saturdayHours, String sundayHours, String phoneNumber, String thumbnailUrl, long visitorReviewCount, long blogReviewCount, double rating) {
+        this.name = name;
+        this.category = category;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.mondayHours = mondayHours;
+        this.tuesdayHours = tuesdayHours;
+        this.wednesdayHours = wednesdayHours;
+        this.thursdayHours = thursdayHours;
+        this.fridayHours = fridayHours;
+        this.saturdayHours = saturdayHours;
+        this.sundayHours = sundayHours;
+        this.phoneNumber = phoneNumber;
+        this.thumbnailUrl = thumbnailUrl;
+        this.visitorReviewCount = visitorReviewCount;
+        this.blogReviewCount = blogReviewCount;
+        this.rating = rating;
+    }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- fix/53/be/model-mapper-error -> develop
- #53  

## 🔑 주요 변경사항
- 에러 메세지를 기록하지 못하는 오류를 수정하기 위해 FailedRecord errormessage 컬럼 length 1024로 증가
- 리스너에 에러 메세지가 1024를 넘어갈때 예외 추가
- Processor에서 ModelMapper 사용하지 않도록 수정
- 리뷰 더보기 버튼을 모두 클릭한 경우 예외처리 추가

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.


