### PR TITLE
feat: 약관 동의 페이지 구현

### DIFF
--- a/fe/lib/model/user.dart
+++ b/fe/lib/model/user.dart
@@ -6,6 +6,13 @@ class User{
   String? userName;
   String? imageUrl;
 
+  bool? finishedSurvey;
+  bool? agreedPrivacyPolicy;
+  bool? agreedTermsOfService;
+  bool? agreedLocationTerms;
+
+  bool? isEnabled;
+
   List<Restaurant> scrapList = [];
 
   User({
@@ -23,6 +30,12 @@ class User{
         .map((item) => Restaurant.fromJson(item as Map<String, dynamic>))
         .toList()
         : [];
+
+    finishedSurvey = json['finishedSurvey'];
+    agreedPrivacyPolicy = json['agreedPrivacyPolicy'];
+    agreedTermsOfService = json['agreedTermsOfService'];
+    agreedLocationTerms = json['agreedLocationTerms'];
+    isEnabled = json['isEnabled'];
   }
 
 

--- a/fe/lib/view/screen/auth_page/register_page.dart
+++ b/fe/lib/view/screen/auth_page/register_page.dart
@@ -4,7 +4,7 @@ import 'package:fe/view/widget/google_login_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../widget/guest_login_button.dart';
+import '../../widget/guest_login_button.dart';
 
 class RegisterPage extends ConsumerWidget {
   const RegisterPage({super.key});

--- a/fe/lib/view/screen/auth_page/survey_first_page.dart
+++ b/fe/lib/view/screen/auth_page/survey_first_page.dart
@@ -1,30 +1,35 @@
+// first_register_selection.dart
 import 'package:fe/data/register_state.dart';
-import 'package:fe/view/screen/register_third_selection_page.dart';
+import 'package:fe/view/screen/auth_page/survey_second_page.dart';
 import 'package:fe/view/widget/register_select_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class SecondRegisterSelection extends ConsumerWidget {
-  const SecondRegisterSelection({super.key});
+class SurveyFirst extends ConsumerWidget {
+  const SurveyFirst({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // step2 데이터를 List<String>으로 캐스팅
-    final step2Data = ref.watch(registrationDataProvider)['step2'] as List<String>;
-    final selectedOptions = step2Data.toSet();
+    // step1 데이터는 이제 List<String> 타입입니다.
+    final step1Data = ref.watch(registrationDataProvider)['step1'] as List<String>;
+    final selectedOptions = step1Data.toSet();
 
-    final String title = "어떤 식당을 좋아하나요?";
+    final String title = "선호하는 분위기를 알려주세요";
     final List<String> options = [
-      "혼밥하기 좋은 곳",
-      "양이 많은 곳",
-      "재료가 신선한 곳",
-      "빨리 나오는 곳",
-      "맛있는 곳"
+      "친절한 곳",
+      "인테리어가 멋진 곳",
+      "가성비 좋은 곳",
+      "청결한 곳",
+      "대화하기 좋은 곳",
+      "단체 모임하기 좋은 곳",
+      "주차하기 편한 곳",
+      "넓은 곳",
+      "뷰가 좋은 곳",
+      "특별한 날 가기 좋은 곳"
     ];
-    final int maxSelection = 2;
+    final int maxSelection = 4;
 
     return Scaffold(
-      appBar: AppBar(backgroundColor: const Color(0xFFDA5100)),
       body: Container(
         color: const Color(0xFFDA5100),
         padding: const EdgeInsets.only(top: 100, bottom: 30),
@@ -48,8 +53,9 @@ class SecondRegisterSelection extends ConsumerWidget {
                 isSelected: selectedOptions.contains(options[i]),
                 onTap: () {
                   final currentData = ref.read(registrationDataProvider);
-                  final currentSelections = List<String>.from(currentData['step2']);
-                  Set<String> newSet = Set<String>.from(currentSelections);
+                  // 현재 step1의 데이터는 List<String>입니다.
+                  final currentSelections = List<String>.from(currentData['step1']);
+                  final Set<String> newSet = Set<String>.from(currentSelections);
                   final String optionValue = options[i];
 
                   if (newSet.contains(optionValue)) {
@@ -58,8 +64,9 @@ class SecondRegisterSelection extends ConsumerWidget {
                     newSet.add(optionValue);
                   }
 
-                  ref.read(registrationDataProvider.notifier)
-                      .updateStepData('step2', newSet.toList());
+                  ref
+                      .read(registrationDataProvider.notifier)
+                      .updateStepData('step1', newSet.toList());
                 },
               ),
               if (i != options.length - 1) const SizedBox(height: 10),
@@ -70,7 +77,7 @@ class SecondRegisterSelection extends ConsumerWidget {
                   ? () => Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => const ThirdRegisterSelection(),
+                  builder: (context) => const SurveySecond(),
                 ),
               )
                   : null,

--- a/fe/lib/view/screen/auth_page/survey_second_page.dart
+++ b/fe/lib/view/screen/auth_page/survey_second_page.dart
@@ -1,35 +1,30 @@
-// first_register_selection.dart
 import 'package:fe/data/register_state.dart';
-import 'package:fe/view/screen/register_second_selection_page.dart';
+import 'package:fe/view/screen/auth_page/survey_third_page.dart';
 import 'package:fe/view/widget/register_select_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class FirstRegisterSelection extends ConsumerWidget {
-  const FirstRegisterSelection({super.key});
+class SurveySecond extends ConsumerWidget {
+  const SurveySecond({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // step1 데이터는 이제 List<String> 타입입니다.
-    final step1Data = ref.watch(registrationDataProvider)['step1'] as List<String>;
-    final selectedOptions = step1Data.toSet();
+    // step2 데이터를 List<String>으로 캐스팅
+    final step2Data = ref.watch(registrationDataProvider)['step2'] as List<String>;
+    final selectedOptions = step2Data.toSet();
 
-    final String title = "선호하는 분위기를 알려주세요";
+    final String title = "어떤 식당을 좋아하나요?";
     final List<String> options = [
-      "친절한 곳",
-      "인테리어가 멋진 곳",
-      "가성비 좋은 곳",
-      "청결한 곳",
-      "대화하기 좋은 곳",
-      "단체 모임하기 좋은 곳",
-      "주차하기 편한 곳",
-      "넓은 곳",
-      "뷰가 좋은 곳",
-      "특별한 날 가기 좋은 곳"
+      "혼밥하기 좋은 곳",
+      "양이 많은 곳",
+      "재료가 신선한 곳",
+      "빨리 나오는 곳",
+      "맛있는 곳"
     ];
-    final int maxSelection = 4;
+    final int maxSelection = 2;
 
     return Scaffold(
+      appBar: AppBar(backgroundColor: const Color(0xFFDA5100)),
       body: Container(
         color: const Color(0xFFDA5100),
         padding: const EdgeInsets.only(top: 100, bottom: 30),
@@ -53,9 +48,8 @@ class FirstRegisterSelection extends ConsumerWidget {
                 isSelected: selectedOptions.contains(options[i]),
                 onTap: () {
                   final currentData = ref.read(registrationDataProvider);
-                  // 현재 step1의 데이터는 List<String>입니다.
-                  final currentSelections = List<String>.from(currentData['step1']);
-                  final Set<String> newSet = Set<String>.from(currentSelections);
+                  final currentSelections = List<String>.from(currentData['step2']);
+                  Set<String> newSet = Set<String>.from(currentSelections);
                   final String optionValue = options[i];
 
                   if (newSet.contains(optionValue)) {
@@ -64,9 +58,8 @@ class FirstRegisterSelection extends ConsumerWidget {
                     newSet.add(optionValue);
                   }
 
-                  ref
-                      .read(registrationDataProvider.notifier)
-                      .updateStepData('step1', newSet.toList());
+                  ref.read(registrationDataProvider.notifier)
+                      .updateStepData('step2', newSet.toList());
                 },
               ),
               if (i != options.length - 1) const SizedBox(height: 10),
@@ -77,7 +70,7 @@ class FirstRegisterSelection extends ConsumerWidget {
                   ? () => Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => const SecondRegisterSelection(),
+                  builder: (context) => const SurveyThird(),
                 ),
               )
                   : null,

--- a/fe/lib/view/screen/auth_page/survey_third_page.dart
+++ b/fe/lib/view/screen/auth_page/survey_third_page.dart
@@ -5,8 +5,8 @@ import 'package:fe/view/widget/register_select_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class ThirdRegisterSelection extends ConsumerWidget {
-  const ThirdRegisterSelection({super.key});
+class SurveyThird extends ConsumerWidget {
+  const SurveyThird({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/fe/lib/view/screen/auth_page/terms_detail_page.dart
+++ b/fe/lib/view/screen/auth_page/terms_detail_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class TermsDetailPage extends StatelessWidget {
+  final String title;
+  final String content;
+
+  TermsDetailPage({required this.title, required this.content});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: Padding(
+        padding: EdgeInsets.all(16),
+        child: Text('여기에 $title 내용이 표시됩니다.', style: TextStyle(fontSize: 16)),
+      ),
+    );
+  }
+}

--- a/fe/lib/view/screen/auth_page/user_terms_page.dart
+++ b/fe/lib/view/screen/auth_page/user_terms_page.dart
@@ -1,0 +1,160 @@
+import 'package:fe/view/screen/auth_page/terms_detail_page.dart';
+import 'package:flutter/material.dart';
+
+class UserTermsPage extends StatefulWidget {
+  @override
+  _UserTermsPageState createState() => _UserTermsPageState();
+}
+
+class _UserTermsPageState extends State<UserTermsPage> {
+  bool _allAgreed = false;
+  bool _ageAgreed = false;
+  bool _serviceAgreed = false;
+  bool _privacyAgreed = false;
+  bool _locationAgreed = false;
+
+  void _updateAllAgreed() {
+    setState(() {
+      _allAgreed = _ageAgreed &&
+          _serviceAgreed &&
+          _privacyAgreed &&
+          _locationAgreed;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('약관 동의')),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 전체 동의
+            CheckboxListTile(
+              title: Text('전체 동의', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              value: _allAgreed,
+              controlAffinity: ListTileControlAffinity.leading,
+              onChanged: (value) {
+                setState(() {
+                  _allAgreed = value!;
+                  _ageAgreed = value;
+                  _serviceAgreed = value;
+                  _privacyAgreed = value;
+                  _locationAgreed = value;
+                });
+              },
+            ),
+            Divider(thickness: 2),
+            SizedBox(height: 16),
+
+            // 개별 약관 동의
+            _buildTermRow(
+              title: '만 14세 이상입니다 (필수)',
+              agreed: _ageAgreed,
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => TermsDetailPage(title: '만 14세 이상 동의', content: '',)),
+              ),
+              onAgreed: (value) => setState(() {
+                _ageAgreed = value;
+                _updateAllAgreed();
+              }),
+            ),
+            _buildTermRow(
+              title: '서비스 이용 약관 동의 (필수)',
+              agreed: _serviceAgreed,
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => TermsDetailPage(title: '서비스 이용 약관', content: '',)),
+              ),
+              onAgreed: (value) => setState(() {
+                _serviceAgreed = value;
+                _updateAllAgreed();
+              }),
+            ),
+            _buildTermRow(
+              title: '개인정보 수집/이용 동의 (필수)',
+              agreed: _privacyAgreed,
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => TermsDetailPage(title: '개인정보 처리 방침', content: '',)),
+              ),
+              onAgreed: (value) => setState(() {
+                _privacyAgreed = value;
+                _updateAllAgreed();
+              }),
+            ),
+            _buildTermRow(
+              title: '위치기반 서비스 이용약관 (필수)',
+              agreed: _locationAgreed,
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => TermsDetailPage(title: '위치기반 서비스 약관', content: '',)),
+              ),
+              onAgreed: (value) => setState(() {
+                _locationAgreed = value;
+                _updateAllAgreed();
+              }),
+            ),
+            SizedBox(height: 32),
+            // 확인 버튼
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: (_ageAgreed && _serviceAgreed && _privacyAgreed && _locationAgreed)
+                    ? () => Navigator.pop(context)
+                    : null,
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Text('확인', style: TextStyle(fontSize: 18)),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTermRow({
+    required String title,
+    required bool agreed,
+    required VoidCallback onPressed,
+    required ValueChanged<bool> onAgreed,
+  }) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextButton(
+              onPressed: onPressed,
+              child: Row(
+                children: [
+                  Text(title, style: TextStyle(color: Colors.black)),
+                  Icon(Icons.arrow_forward_ios, size: 16, color: Colors.grey),
+                ],
+              ),
+              style: TextButton.styleFrom(
+                alignment: Alignment.centerLeft,
+                padding: EdgeInsets.zero,
+              ),
+            ),
+          ),
+          SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () => onAgreed(!agreed),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: agreed ? Colors.blue : Colors.grey,
+              padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            ),
+            child: Text(agreed ? '동의 완료' : '동의'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/fe/lib/view/screen/splash_page.dart
+++ b/fe/lib/view/screen/splash_page.dart
@@ -1,9 +1,12 @@
 import 'package:fe/repository/auth_repository.dart';
 import 'package:fe/view/screen/main_page.dart';
-import 'package:fe/view/screen/register_page.dart';
+import 'package:fe/view/screen/auth_page/survey_first_page.dart';
+import 'package:fe/view/screen/auth_page/register_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dio/dio.dart';
+
+import 'auth_page/user_terms_page.dart';
 
 class SplashScreen extends ConsumerStatefulWidget {
   const SplashScreen({super.key});
@@ -24,9 +27,20 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
 
     final authRepo = ref.read(authRepositoryProvider);
     try {
-      await authRepo.getUser();
-      // 인증 성공 시 메인 화면으로 이동
-      _navigateToMain();
+      final user =  await authRepo.getUser();
+
+      if (user.finishedSurvey == false) {
+        _navigateToSurvey();
+      }
+
+      if (user.agreedPrivacyPolicy == false) {
+        _navigateToTerms();
+      }
+
+      if (user.isEnabled == true) {
+        _navigateToMain();
+      }
+
     } on DioException catch (e) {
       if (e.response?.statusCode == 401) {
         // 401 Unauthorized: 로그인 화면으로 이동
@@ -53,6 +67,18 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   void _navigateToLogin() {
     Navigator.of(context).pushReplacement(
       MaterialPageRoute(builder: (_) => const RegisterPage()),
+    );
+  }
+
+  void _navigateToSurvey() {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const SurveyFirst()),
+    );
+  }
+
+  void _navigateToTerms() {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => UserTermsPage()),
     );
   }
 

--- a/fe/lib/view/screen/splash_page.dart
+++ b/fe/lib/view/screen/splash_page.dart
@@ -31,14 +31,12 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
 
       if (user.finishedSurvey == false) {
         _navigateToSurvey();
-      }
-
-      if (user.agreedPrivacyPolicy == false) {
+      } else if (user.agreedPrivacyPolicy == false) {
         _navigateToTerms();
-      }
-
-      if (user.isEnabled == true) {
+      } else if (user.isEnabled == true) {
         _navigateToMain();
+      } else {
+        _navigateToLogin();
       }
 
     } on DioException catch (e) {

--- a/fe/lib/view/widget/google_login_button.dart
+++ b/fe/lib/view/widget/google_login_button.dart
@@ -1,6 +1,6 @@
 
 import 'package:fe/repository/auth_repository.dart';
-import 'package:fe/view/screen/register_first_selection_page.dart';
+import 'package:fe/view/screen/auth_page/user_terms_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -29,7 +29,7 @@ class GoogleLoginButton extends ConsumerWidget {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => const FirstRegisterSelection(),
+                    builder: (context) => UserTermsPage(),
                   ),
                 );
               } else {

--- a/fe/lib/view/widget/guest_login_button.dart
+++ b/fe/lib/view/widget/guest_login_button.dart
@@ -1,5 +1,5 @@
 import 'package:fe/repository/auth_repository.dart';
-import 'package:fe/view/screen/register_first_selection_page.dart';
+import 'package:fe/view/screen/auth_page/user_terms_page.dart';
 import 'package:fe/view/widget/dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -39,7 +39,7 @@ class GuestLoginButton extends ConsumerWidget {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (context) => const FirstRegisterSelection(),
+                          builder: (context) => UserTermsPage(),
                         ),
                       );
                     } else {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feat/71/agree-terms -> develop
- #71 

## 🔑 주요 변경사항
- 백엔드에서 보낸 약관 동의, 설문 완료 상태를 받고
- Splash page auth check에서 확인 후 올바른 페이지로 route

- 회원가입 후 약관을 동의하기 전에 이탈할 경우, 동의 로직으로 돌아가도록 수정
- 설문을 완료하지 않은 경우도 마찬가지

약관 동의 페이지 구현 작업 포함
약관 동의 페이지 디자인 작업 필요

## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.


