### PR TITLE
chore: 운영DB 설정

### DIFF
--- a/be/.gitignore
+++ b/be/.gitignore
@@ -14,6 +14,8 @@ build/
 
 /src/main/resources/application-oauth.yml
 /src/main/resources/application-jwt.yml
+/src/main/resources/application-dev.yml
+/src/main/resources/application-prod.yml
 
 ### STS ###
 .apt_generated

--- a/be/src/main/resources/application-local.yml
+++ b/be/src/main/resources/application-local.yml
@@ -5,7 +5,6 @@ POSTGRESQL_HOST: localhost
 POSTGRESQL_PORT: 5432
 POSTGRESQL_DATABASE: yumst
 
-# 연결정보 - 로컬
 BASE_URL: http://localhost:8080
 FRONT_URL: http://localhost:8080
 #FRONT_URL: http://localhost:3000

--- a/be/src/main/resources/application-local.yml
+++ b/be/src/main/resources/application-local.yml
@@ -11,3 +11,5 @@ FRONT_URL: http://localhost:8080
 
 REDIS_HOST: localhost
 REDIS_PORT: 6379
+
+CHROME_DRIVER_PATH: "C:\\Users\\Leo\\chromedriver-win64\\chromedriver.exe"

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    include: prod, jwt, oauth
+    include: local, jwt, oauth
 
   datasource:
     url: jdbc:postgresql://${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DATABASE}
@@ -60,4 +60,4 @@ etc:
 
 chrome:
   driver:
-    path: "C:\\Users\\Leo\\chromedriver-win64\\chromedriver.exe"
+    path: ${CHROME_DRIVER_PATH}

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    include: local, jwt, oauth
+    include: prod, jwt, oauth
 
   datasource:
     url: jdbc:postgresql://${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DATABASE}
@@ -60,4 +60,4 @@ etc:
 
 chrome:
   driver:
-    path: "C:\\Users\\Leo\\chromedriver-win64\\chromedriver-win64\\chromedriver.exe"
+    path: "C:\\Users\\Leo\\chromedriver-win64\\chromedriver.exe"


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- chore/86/db-to-rds -> develop
- #86 

## 🔑 주요 변경사항
- 사용 가능한 1만 5천개 데이터를 RDS로 이전 완료했습니다.
- 크롤링 완료된 데이터는 이제 로컬에서 관리하지 않고 바로 운영 DB로 업데이트 됩니다.
- 비용문제로 인해 자동 백업을 하고 있지 않고, 개발 DB와 운영 DB를 따로 두지 않을 것 같습니다. (최대한 수동 백업하려고 노력해 보겠습니다)

운영 DB 환경변수는 노션에 정리해 두겠습니다

**!!!실행 전에 꼭!! 확인해주세요!!!**
1. SPRING profile (local/prod) -> 개발/테스트시 local로 설정
2. ddl-auto -> update or none


## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/c6b6b62b-24fc-4d0e-a989-3dc3a61d257d)


