### PR TITLE
feat: 추천 엔드포인트 V1 업그레이드

### DIFF
--- a/fe/lib/data/location_service.dart
+++ b/fe/lib/data/location_service.dart
@@ -33,6 +33,16 @@ class LocationService {
       throw LocationRetrievalException(e.toString());
     }
   }
+
+  Stream<Position> getPositionStream() {
+    return Geolocator.getPositionStream(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.best,
+        distanceFilter: 500,
+      ),
+    );
+  }
+
 }
 
 // Custom Exception Classes

--- a/fe/lib/data/restaurant_pagination.dart
+++ b/fe/lib/data/restaurant_pagination.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart';
+
+import '../model/restaurant.dart';
+import '../repository/restaurant_repository.dart';
+import 'location_service.dart';
+
+class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaurant>>> {
+  RestaurantPaginationNotifier(this.ref) : super(const AsyncValue.loading()) {
+    loadInitial();
+  }
+
+  final Ref ref;
+  int _currentPage = 1;
+  bool _hasMore = true;
+  Position? _currentPosition;
+
+  // 위치는 initial load 시에만 가져옴 - 페이징 기준을 유지 하기 위해
+  Future<void> loadInitial() async {
+    state = const AsyncValue.loading();
+    try {
+      final locationService = ref.read(locationServiceProvider);
+      _currentPosition = await locationService.getPosition();
+      final repository = ref.read(restaurantRepositoryProvider);
+      final restaurants = await repository.getWalkRecommendations(_currentPosition!, _currentPage);
+      _hasMore = restaurants.isNotEmpty;
+      state = AsyncValue.data(restaurants);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> loadNextPage() async {
+    if (!_hasMore || _currentPosition == null) return;
+
+    _currentPage++;
+    try {
+      final repository = ref.read(restaurantRepositoryProvider);
+      final newRestaurants = await repository.getWalkRecommendations(_currentPosition!, _currentPage);
+      _hasMore = newRestaurants.isNotEmpty;
+      state = AsyncValue.data([...state.value ?? [], ...newRestaurants]);
+    } catch (e, st) {
+      _currentPage--;
+      state = AsyncValue.error(e, st);
+    }
+  }
+}
+
+final restaurantPaginationProvider = StateNotifierProvider.autoDispose<RestaurantPaginationNotifier, AsyncValue<List<Restaurant>>>((ref) {
+  return RestaurantPaginationNotifier(ref);
+});

--- a/fe/lib/data/restaurant_paginator.dart
+++ b/fe/lib/data/restaurant_paginator.dart
@@ -14,9 +14,13 @@ class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaur
 
   final Ref ref;
   int _currentPage = 1;
-  bool _hasMore = true;
   Position? _currentPosition;
   StreamSubscription<Position>? _locationSubscription;
+
+  bool _hasMore = true;
+  bool _isLoadingNextPage = false;
+  bool get hasMore => _hasMore;
+  bool get isLoading => _isLoadingNextPage;
 
   Future<void> _init() async {
     await loadInitial();
@@ -59,10 +63,15 @@ class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaur
   Future<void> loadInitial() async {
     state = const AsyncValue.loading();
     try {
+      _currentPage = 1; // 페이지 번호 초기화 추가
+      _hasMore = true; // 페이지네이션 상태 초기화
+      _isLoadingNextPage = false; // 기존 로딩 상태 취소
+
       final locationService = ref.read(locationServiceProvider);
       _currentPosition = await locationService.getPosition();
       final repository = ref.read(restaurantRepositoryProvider);
       final restaurants = await repository.getWalkRecommendations(_currentPosition!, _currentPage);
+
       _hasMore = restaurants.isNotEmpty;
       state = AsyncValue.data(restaurants);
     } catch (e, st) {
@@ -71,9 +80,11 @@ class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaur
   }
 
   Future<void> loadNextPage() async {
-    if (!_hasMore || _currentPosition == null) return;
+    if (!_hasMore || _currentPosition == null || _isLoadingNextPage) return;
 
+    _isLoadingNextPage = true;
     _currentPage++;
+
     try {
       final repository = ref.read(restaurantRepositoryProvider);
       final newRestaurants = await repository.getWalkRecommendations(_currentPosition!, _currentPage);
@@ -82,6 +93,8 @@ class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaur
     } catch (e, st) {
       _currentPage--;
       state = AsyncValue.error(e, st);
+    } finally {
+      _isLoadingNextPage = false;
     }
   }
 }

--- a/fe/lib/data/restaurant_paginator.dart
+++ b/fe/lib/data/restaurant_paginator.dart
@@ -7,6 +7,9 @@ import '../model/restaurant.dart';
 import '../repository/restaurant_repository.dart';
 import 'location_service.dart';
 
+final transportationModeProvider = StateProvider<String>((ref) => 'walk');
+
+
 class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaurant>>> {
   RestaurantPaginationNotifier(this.ref) : super(const AsyncValue.loading()) {
     _init();
@@ -63,14 +66,20 @@ class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaur
   Future<void> loadInitial() async {
     state = const AsyncValue.loading();
     try {
-      _currentPage = 1; // 페이지 번호 초기화 추가
-      _hasMore = true; // 페이지네이션 상태 초기화
-      _isLoadingNextPage = false; // 기존 로딩 상태 취소
+      _currentPage = 1;
+      _hasMore = true;
+      _isLoadingNextPage = false;
 
+      final transportMode = ref.read(transportationModeProvider);
       final locationService = ref.read(locationServiceProvider);
       _currentPosition = await locationService.getPosition();
+
       final repository = ref.read(restaurantRepositoryProvider);
-      final restaurants = await repository.getWalkRecommendations(_currentPosition!, _currentPage);
+      final restaurants = await repository.getRecommendations(
+        _currentPosition!,
+        _currentPage,
+        transportMode: transportMode, // 이동 수단 파라미터 추가
+      );
 
       _hasMore = restaurants.isNotEmpty;
       state = AsyncValue.data(restaurants);
@@ -79,15 +88,22 @@ class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaur
     }
   }
 
+  // 이동 수단 변경 시 초기화 메서드
+  Future<void> switchTransportMode(String newMode) async {
+    ref.read(transportationModeProvider.notifier).state = newMode;
+    await loadInitial();
+  }
+
   Future<void> loadNextPage() async {
     if (!_hasMore || _currentPosition == null || _isLoadingNextPage) return;
 
     _isLoadingNextPage = true;
     _currentPage++;
+    final transportMode = ref.read(transportationModeProvider);
 
     try {
       final repository = ref.read(restaurantRepositoryProvider);
-      final newRestaurants = await repository.getWalkRecommendations(_currentPosition!, _currentPage);
+      final newRestaurants = await repository.getRecommendations(_currentPosition!, _currentPage, transportMode: transportMode);
       _hasMore = newRestaurants.isNotEmpty;
       state = AsyncValue.data([...state.value ?? [], ...newRestaurants]);
     } catch (e, st) {

--- a/fe/lib/data/restaurant_paginator.dart
+++ b/fe/lib/data/restaurant_paginator.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 
@@ -7,13 +9,51 @@ import 'location_service.dart';
 
 class RestaurantPaginationNotifier extends StateNotifier<AsyncValue<List<Restaurant>>> {
   RestaurantPaginationNotifier(this.ref) : super(const AsyncValue.loading()) {
-    loadInitial();
+    _init();
   }
 
   final Ref ref;
   int _currentPage = 1;
   bool _hasMore = true;
   Position? _currentPosition;
+  StreamSubscription<Position>? _locationSubscription;
+
+  Future<void> _init() async {
+    await loadInitial();
+    _setupLocationListener();
+  }
+
+  void _setupLocationListener() {
+    _locationSubscription = ref
+        .read(locationServiceProvider)
+        .getPositionStream()
+        .listen((newPosition) {
+      _handlePositionChange(newPosition);
+    });
+  }
+
+  void _handlePositionChange(Position newPosition) {
+    if (_currentPosition == null) return;
+
+    final distance = Geolocator.distanceBetween(
+      _currentPosition!.latitude,
+      _currentPosition!.longitude,
+      newPosition.latitude,
+      newPosition.longitude,
+    );
+
+    // 1km 이상 이동 시 새로고침
+    if (distance > 1000) {
+      _currentPosition = newPosition;
+      loadInitial();
+    }
+  }
+
+  @override
+  void dispose() {
+    _locationSubscription?.cancel();
+    super.dispose();
+  }
 
   // 위치는 initial load 시에만 가져옴 - 페이징 기준을 유지 하기 위해
   Future<void> loadInitial() async {

--- a/fe/lib/model/restaurant.dart
+++ b/fe/lib/model/restaurant.dart
@@ -14,6 +14,7 @@ class Restaurant {
     required this.isScrapped,
     required this.likeCount,
     required this.dislikeCount,
+    required this.distance
   });
 
   String? restaurantId;
@@ -34,6 +35,8 @@ class Restaurant {
   int? likeCount;
   int? dislikeCount;
 
+  double? distance;
+
   Restaurant.fromJson(Map<String, dynamic> json) {
     restaurantId = json['restaurantId'];
     name = json['name'];
@@ -49,6 +52,7 @@ class Restaurant {
     isScrapped = json['scrapped'];
     likeCount = json['likeCount'];
     dislikeCount = json['dislikeCount'];
+    distance = json['distance'];
   }
 
   Map<String, dynamic> toJson() {

--- a/fe/lib/repository/restaurant_repository.dart
+++ b/fe/lib/repository/restaurant_repository.dart
@@ -20,7 +20,7 @@ class RestaurantRepository {
   });
   final Dio dio;
 
-  Future<List<Restaurant>> getRestaurants(Position position) async {
+  Future<List<Restaurant>> getRestaurantsV0(Position position) async {
 
     print("**********위도 경도********");
     print(position.latitude.toString());
@@ -28,6 +28,24 @@ class RestaurantRepository {
 
 
     final response = await dio.get("http://localhost:8080/api/recommendation/v0");
+
+    if (response.statusCode == 200) {
+      final List<dynamic> data = response.data;
+      return data.map((json) => Restaurant.fromJson(json)).toList();
+    } else {
+      throw Exception("식당 정보를 불러오는데 실패했습니다.");
+    }
+  }
+
+  Future<List<Restaurant>> getWalkRecommendations(Position position, int page) async {
+    final response = await dio.get(
+      "http://localhost:8080/api/recommendation/v1/walk",
+      queryParameters: {
+        'latitude': position.latitude,
+        'longitude': position.longitude,
+        'page': page,
+      },
+    );
 
     if (response.statusCode == 200) {
       final List<dynamic> data = response.data;

--- a/fe/lib/repository/restaurant_repository.dart
+++ b/fe/lib/repository/restaurant_repository.dart
@@ -37,9 +37,15 @@ class RestaurantRepository {
     }
   }
 
-  Future<List<Restaurant>> getWalkRecommendations(Position position, int page) async {
+  Future<List<Restaurant>> getRecommendations(
+      Position position,
+      int page, {
+        required String transportMode,
+      }) async {
     final response = await dio.get(
-      "http://localhost:8080/api/recommendation/v1/walk",
+      transportMode == 'walk'
+          ? "http://localhost:8080/api/recommendation/v1/walk"
+          : "http://localhost:8080/api/recommendation/v1/car",
       queryParameters: {
         'latitude': position.latitude,
         'longitude': position.longitude,
@@ -56,7 +62,7 @@ class RestaurantRepository {
   }
 
   Future scrapRestaurant(Restaurant restaurant) async {
-    final response = await dio.post(
+    final response = await dio.patch(
         "http://localhost:8080/api/user/v1/scrap/${restaurant.restaurantId}"
     );
     if (response.statusCode == 200) {

--- a/fe/lib/view/screen/main_page.dart
+++ b/fe/lib/view/screen/main_page.dart
@@ -1,16 +1,21 @@
 import 'package:fe/view/screen/my_page.dart';
 import 'package:fe/view/screen/recommendation_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class MainScreen extends StatefulWidget {
+import '../../data/restaurant_paginator.dart';
+
+class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key});
 
   @override
-  State<MainScreen> createState() => _MainScreenState();
+  ConsumerState<MainScreen> createState() => _MainScreenState();
 }
 
-class _MainScreenState extends State<MainScreen> {
+class _MainScreenState extends ConsumerState<MainScreen> {
   int _selectedIndex = 0;
+  DateTime? _lastTapTime;
+  int? _lastTappedIndex;
 
   static final List<Widget> _pages = [
     RecommendationPage(),
@@ -18,25 +23,50 @@ class _MainScreenState extends State<MainScreen> {
     MyPageScreen(),
   ];
 
-  void _onItemTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
+  void _handleTabInteraction(int index) {
+    final currentTime = DateTime.now();
+
+    if (_lastTappedIndex == index &&
+        _lastTapTime != null &&
+        currentTime.difference(_lastTapTime!) < const Duration(milliseconds: 300)) {
+      // 더블 탭 처리
+      if (index == 0 && _selectedIndex == 0) {
+        ref.read(restaurantPaginationProvider.notifier).loadInitial();
+      }
+      _lastTapTime = null;
+      _lastTappedIndex = null;
+    } else {
+      // 싱글 탭 처리
+      setState(() => _selectedIndex = index);
+      _lastTapTime = currentTime;
+      _lastTappedIndex = index;
+    }
   }
 
   Widget _buildNavItem(IconData icon, int index) {
-    Color iconColor;
-    if (_selectedIndex == 0) {
-      // 추천 페이지일 때: 활성은 흰색, 비활성은 회색 (검은색 배경)
-      iconColor = (_selectedIndex == index) ? Colors.white : Colors.grey;
-    } else {
-      // 그 외 페이지: 활성은 검은색, 비활성은 회색 (흰색 배경)
-      iconColor = (_selectedIndex == index) ? Colors.black : Colors.grey;
-    }
-    return IconButton(
-      icon: Icon(icon, color: iconColor, size: 28),
-      onPressed: () => _onItemTapped(index),
+    final isRecommendationTab = _selectedIndex == 0;
+    final isActive = _selectedIndex == index;
+
+    return InkWell(
+      onTap: () => _handleTabInteraction(index),
+      borderRadius: BorderRadius.circular(50),
+      splashColor: isRecommendationTab ? Colors.white30 : Colors.black12,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Icon(
+          icon,
+          color: _getIconColor(isRecommendationTab, isActive),
+          size: 28,
+        ),
+      ),
     );
+  }
+
+  Color _getIconColor(bool isRecommendationTab, bool isActive) {
+    if (isRecommendationTab) {
+      return isActive ? Colors.white : Colors.grey;
+    }
+    return isActive ? Colors.black : Colors.grey;
   }
 
   @override
@@ -46,29 +76,27 @@ class _MainScreenState extends State<MainScreen> {
         index: _selectedIndex,
         children: _pages,
       ),
-      bottomNavigationBar: Container(
-        decoration: BoxDecoration(
-          color: _selectedIndex == 0 ? Colors.black : Colors.white,
-          border: Border(
-            top: BorderSide(
-              color: Colors.grey.shade300,
-              width: 0.5,
-            ),
-          ),
-        ),
-        // 필요시 margin이나 padding 값을 조정하여 위치 미세 조정 가능
-        child: SafeArea(
-          top: false,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 5),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                _buildNavItem(Icons.local_dining, 0),
-                _buildNavItem(Icons.how_to_vote, 1),
-                _buildNavItem(Icons.person, 2),
-              ],
-            ),
+      bottomNavigationBar: _buildBottomNavBar(),
+    );
+  }
+
+  Widget _buildBottomNavBar() {
+    return Container(
+      decoration: BoxDecoration(
+        color: _selectedIndex == 0 ? Colors.black : Colors.white,
+        border: Border(top: BorderSide(color: Colors.grey.shade300, width: 0.5)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 5),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _buildNavItem(Icons.local_dining, 0),
+              _buildNavItem(Icons.how_to_vote, 1),
+              _buildNavItem(Icons.person, 2),
+            ],
           ),
         ),
       ),

--- a/fe/lib/view/screen/recommendation_page.dart
+++ b/fe/lib/view/screen/recommendation_page.dart
@@ -3,6 +3,7 @@ import 'package:fe/repository/restaurant_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:card_swiper/card_swiper.dart';
+import '../../data/restaurant_pagination.dart';
 import '../../model/restaurant.dart';
 import '../widget/reels_style_card.dart';
 
@@ -10,7 +11,7 @@ final restaurantsFutureProvider = FutureProvider<List<Restaurant>>((ref) async {
   final repository = ref.watch(restaurantRepositoryProvider);
   final locationService = ref.watch(locationServiceProvider);
   final position = await locationService.getPosition();
-  return repository.getRestaurants(position);
+  return repository.getRestaurantsV0(position);
 });
 
 class RecommendationPage extends ConsumerWidget {
@@ -18,23 +19,23 @@ class RecommendationPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final restaurantsAsync = ref.watch(restaurantsFutureProvider);
+    final restaurantsAsync = ref.watch(restaurantPaginationProvider);
 
-    return restaurantsAsync.when(
-      data: (restaurants) => Scaffold(
-        body: Swiper(
-          itemCount: restaurants.length,
+    return Scaffold(
+      body: restaurantsAsync.when(
+        data: (restaurants) => Swiper(
+          itemCount: restaurants.length + 1, // +1 for loading indicator
           scrollDirection: Axis.vertical,
-          itemBuilder: (BuildContext context, int index) {
+          itemBuilder: (context, index) {
+            if (index == restaurants.length) {
+              ref.read(restaurantPaginationProvider.notifier).loadNextPage();
+              return const Center(child: CircularProgressIndicator());
+            }
             return ReelsStyleCard(restaurant: restaurants[index]);
           },
         ),
-      ),
-      loading: () => const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      ),
-      error: (error, stackTrace) => Scaffold(
-        body: Center(child: Text("Error: $error")),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => Center(child: Text("Error: $error")),
       ),
     );
   }

--- a/fe/lib/view/screen/recommendation_page.dart
+++ b/fe/lib/view/screen/recommendation_page.dart
@@ -3,7 +3,7 @@ import 'package:fe/repository/restaurant_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:card_swiper/card_swiper.dart';
-import '../../data/restaurant_pagination.dart';
+import '../../data/restaurant_paginator.dart';
 import '../../model/restaurant.dart';
 import '../widget/reels_style_card.dart';
 

--- a/fe/lib/view/screen/recommendation_page.dart
+++ b/fe/lib/view/screen/recommendation_page.dart
@@ -14,21 +14,50 @@ final restaurantsFutureProvider = FutureProvider<List<Restaurant>>((ref) async {
   return repository.getRestaurantsV0(position);
 });
 
-class RecommendationPage extends ConsumerWidget {
+class RecommendationPage extends ConsumerStatefulWidget {
   const RecommendationPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<RecommendationPage> createState() => _RecommendationPageState();
+}
+
+class _RecommendationPageState extends ConsumerState<RecommendationPage> {
+  final SwiperController _swiperController = SwiperController();
+  final int _preloadThreshold = 4; // 6번째에서 미리 로드
+
+  void _handleIndexChanged(int index) {
+    final asyncValue = ref.read(restaurantPaginationProvider);
+    final notifier = ref.read(restaurantPaginationProvider.notifier);
+
+    if (asyncValue is! AsyncData) return;
+
+    final remainingItems = asyncValue.value!.length - index;
+    if (remainingItems <= _preloadThreshold &&
+        notifier.hasMore &&
+        !notifier.isLoading) {
+      notifier.loadNextPage();
+    }
+  }
+
+  @override
+  void dispose() {
+    _swiperController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final restaurantsAsync = ref.watch(restaurantPaginationProvider);
 
     return Scaffold(
       body: restaurantsAsync.when(
         data: (restaurants) => Swiper(
-          itemCount: restaurants.length + 1, // +1 for loading indicator
+          controller: _swiperController,
+          onIndexChanged: _handleIndexChanged,
+          itemCount: restaurants.length + 1,
           scrollDirection: Axis.vertical,
           itemBuilder: (context, index) {
             if (index == restaurants.length) {
-              ref.read(restaurantPaginationProvider.notifier).loadNextPage();
               return const Center(child: CircularProgressIndicator());
             }
             return ReelsStyleCard(restaurant: restaurants[index]);

--- a/fe/lib/view/widget/reels_style_card.dart
+++ b/fe/lib/view/widget/reels_style_card.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fe/model/restaurant.dart';
 import 'package:fe/repository/restaurant_repository.dart';
 
+import '../../data/restaurant_paginator.dart';
+
 class ReelsStyleCard extends ConsumerStatefulWidget {
   final Restaurant restaurant;
 
@@ -259,7 +261,33 @@ class _ReelsStyleCardState extends ConsumerState<ReelsStyleCard>
                         mainAxisSize: MainAxisSize.min,
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: [
-                          // TODO: 여기에 신고 / 투표 좋아요 싫어요 개수 / 공유 버튼 추가
+                          // 이동 수단 토글 버튼
+                          Consumer(
+                            builder: (context, ref, _) {
+                              final transportMode = ref.watch(transportationModeProvider);
+                              return IconButton(
+                                icon: AnimatedSwitcher(
+                                  duration: const Duration(milliseconds: 200),
+                                  child: transportMode == 'car'
+                                      ? const Icon(
+                                    Icons.directions_car, // 색칠된 차량 아이콘
+                                    key: ValueKey('car_filled'),
+                                    color: Colors.white,
+                                  )
+                                      : const Icon(
+                                    Icons.directions_car_outlined, // 테두리만 있는 차량 아이콘
+                                    key: ValueKey('car_outlined'),
+                                    color: Colors.white70,
+                                  ),
+                                ),
+                                onPressed: () {
+                                  final newMode = transportMode == 'car' ? 'walk' : 'car';
+                                  ref.read(transportationModeProvider.notifier).state = newMode;
+                                },
+                              );
+                            },
+                          ),
+                          SizedBox(height: 10),
                           IconButton(
                             icon: Icon(
                               (restaurant.isScrapped ?? false)
@@ -270,7 +298,7 @@ class _ReelsStyleCardState extends ConsumerState<ReelsStyleCard>
                             onPressed: _toggleScrap,
                           ),
                         ],
-                      ),
+                      )
                     ),
                   ],
                 ),

--- a/fe/lib/view/widget/reels_style_card.dart
+++ b/fe/lib/view/widget/reels_style_card.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fe/model/restaurant.dart';
@@ -83,15 +84,23 @@ class _ReelsStyleCardState extends ConsumerState<ReelsStyleCard>
         fit: StackFit.expand,
         children: [
           /// 1) 배경 이미지
-          Image.network(
-            restaurant.thumbnailUrl ?? '',
+          CachedNetworkImage(
+            imageUrl: restaurant.thumbnailUrl ?? '',
             fit: BoxFit.cover,
-            errorBuilder: (context, error, stackTrace) =>
+            fadeInDuration: Duration.zero,
+            fadeOutDuration: Duration.zero,
+            errorWidget: (context, url, error) =>
             const Center(child: Icon(Icons.error)),
-            loadingBuilder: (context, child, loadingProgress) {
-              if (loadingProgress == null) return child;
-              return const Center(child: CircularProgressIndicator());
-            },
+            progressIndicatorBuilder: (context, url, progress) =>
+            const Center(child: CircularProgressIndicator()),
+            imageBuilder: (context, imageProvider) => Container(
+              decoration: BoxDecoration(
+                image: DecorationImage(
+                  image: imageProvider,
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
           ),
 
           /// 2) 펼쳤을 때 배경 어둡게 처리

--- a/fe/lib/view/widget/reels_style_card.dart
+++ b/fe/lib/view/widget/reels_style_card.dart
@@ -170,6 +170,15 @@ class _ReelsStyleCardState extends ConsumerState<ReelsStyleCard>
                                             color: Colors.white,
                                             fontWeight: FontWeight.bold,
                                           ),
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                        Text(
+                                          '${restaurant.distance?.toStringAsFixed(0) ?? 'N/A'}m',
+                                          style: const TextStyle(
+                                            fontSize: 18,
+                                            color: Colors.white70,
+                                            fontWeight: FontWeight.w500,
+                                          ),
                                         ),
                                         const SizedBox(height: 4),
                                         Row(

--- a/fe/pubspec.yaml
+++ b/fe/pubspec.yaml
@@ -66,6 +66,7 @@ dev_dependencies:
 flutter:
   assets:
     - assets/images/
+    - assets/terms/
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in


### PR DESCRIPTION
## <i>PULL REQUEST</i>

## 🎋 작업 브랜치
- feat/70/fe/recommend-scroll -> develop

close #70 , #98 , #79 

## 🔑 주요 변경사항

- 추천 엔드포인트 V0 -> V1 업그레이드

- 사용자와 식당의 거리를 표시하도록 수정

- UX를 위해 미리 로딩하는 방식으로 변경
   로딩 시간이 약 1.5 ~ 2.5s
   6번째 식당을 보는 순간 미리 로딩하도록 로직을 추가해서 끊김 없이 추천 받을 수 있습니다

- 차량 / 도보 옵션을 토글 할 수 있도록 수정
    차량 도보 옵션을 토글시 기존에는 새로고침을 넣으려고 했는데, UX에 좋지 않을 것 같아 다음 추천 리스트 부터 다른 옵션으로 추천받도록 수정했습니다.
    페이징 기준이 달라진다는 문제점이 있지만 같은 위치 기준이라면 괜찮을 것 같아 이렇게 구현했습니다 

- 사진 로딩이 시간이 좀 걸리는 것 같아서 Network Image -> Cached Network Image 위젯으로 변경
   어느정도 성능 개선이 되는지 확인하지는 못했습니다

- 추천 페이지 바텀 내비게이션 바를 더블 클릭해서 새로고침하도록 수정

- 사용자가 최초 추천 받는 위치에서 1km 이상 이동하면 그 위치를 기준으로 다시 추천받도록 수정
   구현하기 위해 Listener를 추가했습니다 - 성능에 악영향을 좀 미칠 수도 있을 것 같습니다
   페이징 기준이 바뀌면 같은 식당을 자꾸 추천 받아서 위치를 고정 시켰는데, 너무 많이 벗어나면 새로운 위치를 기준으로 추천해야 할 것 같아서 1km를 임시 기준으로 잡았습니다


차량 기준으로 추천 받을 시 추천 로직을 손 봐야할 것 같습니다.
술집, 주차가 편해요 특징이 있는 식당 점수 강화 등


## 🏞 스크린샷 (선택)
> 스크린샷을 첨부해주세요.
<img width="392" alt="image" src="https://github.com/user-attachments/assets/3e24408d-78d9-42fc-97cd-9b182326b7cd" />
<img width="375" alt="image" src="https://github.com/user-attachments/assets/6b919a95-9c69-4bb3-8933-f68a07845699" />
<img width="383" alt="image" src="https://github.com/user-attachments/assets/e1ca586b-f293-4871-b70a-a9cd56dd9c2d" />
<img width="384" alt="image" src="https://github.com/user-attachments/assets/bb30bd11-c7b3-4c1b-bf77-99b6e1762eb4" />

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/80c8d622-e7ec-490b-a8ed-5717fef01347" />


